### PR TITLE
1.1.2 Update

### DIFF
--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -132,8 +132,7 @@ namespace BUDDYWORKS.UnityPackageIcon
         [MenuItem("BUDDYWORKS/Set .unitypackage Icon...")]
         public static void ShowWindow()
         {
-            UnityPackageIcon window = (UnityPackageIcon)GetWindow(typeof(UnityPackageIcon));
-            window.titleContent = new GUIContent("UnityPackage Icon Tool");
+            GetWindow<UnityPackageIcon>(true, "UnityPackage Icon Tool");
         }
 
 

--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -130,13 +130,12 @@ namespace BUDDYWORKS.UnityPackageIcon
         }
 
         [MenuItem("BUDDYWORKS/Set .unitypackage Icon...")]
-        public static void ShowWindow()
+        private static void ShowWindow()
         {
             GetWindow<UnityPackageIcon>(true, "UnityPackage Icon Tool");
         }
 
-
-        void OnGUI()
+        private void OnGUI()
         {
             EditorGUILayout.Space();
             using (new EditorGUILayout.HorizontalScope())
@@ -153,7 +152,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             GUILayout.Label("- Source image should be small in resolution. (128x128px recommended)");
             GUILayout.Label("Note: Image selection is remembered for this project.", EditorStyles.boldLabel);
             GUILayout.FlexibleSpace();
-            
+
             GUILayout.Label("UnityPackage Icon Tool - Made by dor_ for BUDDYWORKS", EditorStyles.boldLabel);
             Rect labelRect = GUILayoutUtility.GetLastRect();
             if (Event.current.type == EventType.MouseDown && labelRect.Contains(Event.current.mousePosition))

--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -129,7 +129,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             Harmony.Patch(showExportPackageMethod, null, new HarmonyMethod(typeof(UnityPackageIcon).GetMethod(nameof(ShowExportPackage), BindingFlags.NonPublic | BindingFlags.Static)));
         }
 
-        [MenuItem("BUDDYWORKS/Set .UnityPackage Icon Tool...")]
+        [MenuItem("BUDDYWORKS/Set .UnityPackage Icon...")]
         public static void ShowWindow()
         {
             UnityPackageIcon window = (UnityPackageIcon)GetWindow(typeof(UnityPackageIcon));

--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -49,14 +49,14 @@ namespace BUDDYWORKS.UnityPackageIcon
 
         static UnityPackageIcon()
         {
-                if (File.Exists(IconSavePath))
+            if (File.Exists(IconSavePath))
+            {
+                string guid = File.ReadAllText(IconSavePath);
+                if (!string.IsNullOrEmpty(guid))
                 {
-                    string guid = File.ReadAllText(IconSavePath);
-                    if (!string.IsNullOrEmpty(guid))
-                    {
-                        SelectedIcon = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(guid));
-                    }
+                    SelectedIcon = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(guid));
                 }
+            }
 
             Harmony = new Harmony(PackageName);
 

--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -145,39 +145,22 @@ namespace BUDDYWORKS.UnityPackageIcon
                 EditorGUILayout.LabelField("Select package icon:", EditorStyles.boldLabel, GUILayout.Width(128), GUILayout.Height(64));
                 SelectedIcon = (Texture2D)EditorGUILayout.ObjectField(GUIContent.none, SelectedIcon, typeof(Texture2D), false, GUILayout.Height(64), GUILayout.Width(64));
             }
-                EditorGUILayout.Space();
-                DrawHorizontalLine();
-                GUILayout.Label("Icons must meet the following requirements:", EditorStyles.largeLabel);
-                GUILayout.Label("- Must be a .png");
-                GUILayout.Label("- Should be squared (1:1)");
-                GUILayout.Label("- Source image should be small in resolution. (128x128px recommended)");
-                GUILayout.Label("Note: Image selection is remembered for this project.", EditorStyles.boldLabel);
-                GUILayout.FlexibleSpace();
-                GUILayout.Label("UnityPackage Icon Tool - Made by dor_ for BUDDYWORKS", EditorStyles.boldLabel);
-                    Rect labelRect = GUILayoutUtility.GetLastRect();
-
-                    if (Event.current.type == EventType.MouseDown && labelRect.Contains(Event.current.mousePosition))
-                    {
-                        OpenWebsite("https://github.com/JustBuddy/unitypackage-icon-tool");
-                    }
-        }
-
-        private void OpenWebsite(string url)
-        {
-            Application.OpenURL(url);
-        }
-
-        private void DrawHorizontalLine()
-        {
-            GUIStyle horizontalLine = new GUIStyle();
-            horizontalLine.normal.background = EditorGUIUtility.whiteTexture;
-            horizontalLine.margin = new RectOffset(0, 0, 4, 4);
-            horizontalLine.fixedHeight = 1;
-
-            Color oldColor = GUI.color;
-            GUI.color = Color.gray;
-            GUILayout.Box(GUIContent.none, horizontalLine);
-            GUI.color = oldColor;
+            EditorGUILayout.Space();
+            Rect r = EditorGUILayout.GetControlRect(false, 1, new GUIStyle() { margin = new RectOffset(0, 0, 4, 4) });
+            EditorGUI.DrawRect(r, Color.gray);
+            GUILayout.Label("Icons must meet the following requirements:", EditorStyles.largeLabel);
+            GUILayout.Label("- Must be a .png");
+            GUILayout.Label("- Should be squared (1:1)");
+            GUILayout.Label("- Source image should be small in resolution. (128x128px recommended)");
+            GUILayout.Label("Note: Image selection is remembered for this project.", EditorStyles.boldLabel);
+            GUILayout.FlexibleSpace();
+            
+            GUILayout.Label("UnityPackage Icon Tool - Made by dor_ for BUDDYWORKS", EditorStyles.boldLabel);
+            Rect labelRect = GUILayoutUtility.GetLastRect();
+            if (Event.current.type == EventType.MouseDown && labelRect.Contains(Event.current.mousePosition))
+            {
+                Application.OpenURL("https://github.com/JustBuddy/unitypackage-icon-tool");
+            }
         }
 
         private static void UpdateIcon(Texture2D icon)

--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -38,7 +38,7 @@ namespace BUDDYWORKS.UnityPackageIcon
     public class UnityPackageIcon : EditorWindow
     {
         private const string PackageName = "wtf.buddyworks.uit";
-        private static string IconSavePath = $"Packages/{PackageName}/selectedIcon.txt";
+        private static string IconSavePath = $"Assets/UIT_ExportPackageIcon.txt";
 
         private static Texture2D _selectedIcon = null;
         private static Texture2D SelectedIcon { get { return _selectedIcon; } set { UpdateIcon(value); } }
@@ -49,21 +49,21 @@ namespace BUDDYWORKS.UnityPackageIcon
 
         static UnityPackageIcon()
         {
-            if (File.Exists(IconSavePath))
-            {
-                string guid = File.ReadAllText(IconSavePath);
-                if (!string.IsNullOrEmpty(guid))
+                if (File.Exists(IconSavePath))
                 {
-                    SelectedIcon = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(guid));
+                    string guid = File.ReadAllText(IconSavePath);
+                    if (!string.IsNullOrEmpty(guid))
+                    {
+                        SelectedIcon = AssetDatabase.LoadAssetAtPath<Texture2D>(AssetDatabase.GUIDToAssetPath(guid));
+                    }
                 }
-            }
 
             Harmony = new Harmony(PackageName);
 
             Type packageExportType = typeof(EditorWindow).Assembly.GetType("UnityEditor.PackageExport");
             if (packageExportType == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the type UnityEditor.PackageExport!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the type UnityEditor.PackageExport!");
 
                 return;
             }
@@ -71,7 +71,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             MethodInfo exportMethod = packageExportType.GetMethod("Export", BindingFlags.NonPublic | BindingFlags.Instance);
             if (exportMethod == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the method UnityEditor.PackageExport.Export()!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the method UnityEditor.PackageExport.Export()!");
 
                 return;
             }
@@ -79,7 +79,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             TopAreaMethod = packageExportType.GetMethod("TopArea", BindingFlags.NonPublic | BindingFlags.Instance);
             if (TopAreaMethod == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the method UnityEditor.PackageExport.TopArea()!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the method UnityEditor.PackageExport.TopArea()!");
 
                 return;
             }
@@ -87,7 +87,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             MethodInfo showExportPackageMethod = packageExportType.GetMethod("ShowExportPackage", BindingFlags.NonPublic | BindingFlags.Static);
             if (showExportPackageMethod == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the method UnityEditor.PackageExport.ShowExportPackage()!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the method UnityEditor.PackageExport.ShowExportPackage()!");
 
                 return;
             }
@@ -95,7 +95,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             m_ExportPackageItemsField = packageExportType.GetField("m_ExportPackageItems", BindingFlags.NonPublic | BindingFlags.Instance);
             if (m_ExportPackageItemsField == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the field UnityEditor.PackageExport.m_ExportPackageItems!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the field UnityEditor.PackageExport.m_ExportPackageItems!");
 
                 return;
             }
@@ -104,7 +104,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             Type exportPackageItemType = typeof(EditorWindow).Assembly.GetType("UnityEditor.ExportPackageItem");
             if (exportPackageItemType == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the type UnityEditor.ExportPackageItem!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the type UnityEditor.ExportPackageItem!");
 
                 return;
             }
@@ -112,7 +112,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             enabledStatusField = exportPackageItemType.GetField("enabledStatus", BindingFlags.Public | BindingFlags.Instance);
             if (enabledStatusField == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the field UnityEditor.ExportPackageItem.enabledStatusField!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the field UnityEditor.ExportPackageItem.enabledStatusField!");
 
                 return;
             }
@@ -120,7 +120,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             guidField = exportPackageItemType.GetField("guid", BindingFlags.Public | BindingFlags.Instance);
             if (guidField == null)
             {
-                Debug.LogError("[UnityPackage Icon] Failed to find the field UnityEditor.ExportPackageItem.guid!");
+                Debug.LogError("[UnityPackage Icon Tool] Failed to find the field UnityEditor.ExportPackageItem.guid!");
 
                 return;
             }
@@ -129,24 +129,55 @@ namespace BUDDYWORKS.UnityPackageIcon
             Harmony.Patch(showExportPackageMethod, null, new HarmonyMethod(typeof(UnityPackageIcon).GetMethod(nameof(ShowExportPackage), BindingFlags.NonPublic | BindingFlags.Static)));
         }
 
-        [MenuItem("BUDDYWORKS/Set .unitypackage icon...")]
-        private static void Init()
+        [MenuItem("BUDDYWORKS/Set .UnityPackage Icon Tool...")]
+        public static void ShowWindow()
         {
             UnityPackageIcon window = (UnityPackageIcon)GetWindow(typeof(UnityPackageIcon));
-
-            window.titleContent = new GUIContent("UnityPackage Icon");
-
-            //window.Show();
-            window.ShowModal();
+            window.titleContent = new GUIContent("UnityPackage Icon Tool");
         }
 
-        private void OnGUI()
+
+        void OnGUI()
         {
+            EditorGUILayout.Space();
             using (new EditorGUILayout.HorizontalScope())
             {
-                EditorGUILayout.LabelField("Package icon:", EditorStyles.boldLabel, GUILayout.Width(84), GUILayout.Height(64));
+                EditorGUILayout.LabelField("Select package icon:", EditorStyles.boldLabel, GUILayout.Width(128), GUILayout.Height(64));
                 SelectedIcon = (Texture2D)EditorGUILayout.ObjectField(GUIContent.none, SelectedIcon, typeof(Texture2D), false, GUILayout.Height(64), GUILayout.Width(64));
             }
+                EditorGUILayout.Space();
+                DrawHorizontalLine();
+                GUILayout.Label("Icons must meet the following requirements:", EditorStyles.largeLabel);
+                GUILayout.Label("- Must be a .png");
+                GUILayout.Label("- Should be squared (1:1)");
+                GUILayout.Label("- Source image should be small in resolution. (128x128px recommended)");
+                GUILayout.Label("Note: Image selection is remembered for this project.", EditorStyles.boldLabel);
+                GUILayout.FlexibleSpace();
+                GUILayout.Label("UnityPackage Icon Tool - Made by dor_ for BUDDYWORKS", EditorStyles.boldLabel);
+                    Rect labelRect = GUILayoutUtility.GetLastRect();
+
+                    if (Event.current.type == EventType.MouseDown && labelRect.Contains(Event.current.mousePosition))
+                    {
+                        OpenWebsite("https://github.com/JustBuddy/unitypackage-icon-tool");
+                    }
+        }
+
+        private void OpenWebsite(string url)
+        {
+            Application.OpenURL(url);
+        }
+
+        private void DrawHorizontalLine()
+        {
+            GUIStyle horizontalLine = new GUIStyle();
+            horizontalLine.normal.background = EditorGUIUtility.whiteTexture;
+            horizontalLine.margin = new RectOffset(0, 0, 4, 4);
+            horizontalLine.fixedHeight = 1;
+
+            Color oldColor = GUI.color;
+            GUI.color = Color.gray;
+            GUILayout.Box(GUIContent.none, horizontalLine);
+            GUI.color = oldColor;
         }
 
         private static void UpdateIcon(Texture2D icon)
@@ -162,7 +193,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 {
                     _selectedIcon = null;
 
-                    Debug.LogError("[UnityPackage Icon] The path to the icon could not be found!");
+                    Debug.LogError("[UnityPackage Icon Tool] The path to the icon could not be found!");
 
                     return;
                 }
@@ -170,7 +201,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 {
                     _selectedIcon = null;
 
-                    Debug.LogError("[UnityPackage Icon] The icon must be PNG formatted!");
+                    Debug.LogError("[UnityPackage Icon Tool] The icon must be PNG formatted!");
 
                     return;
                 }
@@ -201,7 +232,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             string iconPath = AssetDatabase.GetAssetPath(SelectedIcon);
             if (string.IsNullOrEmpty(iconPath))
             {
-                Debug.LogWarning("[UnityPackage Icon] The selected icon's path cannot be found, exporting without icon!");
+                Debug.LogWarning("[UnityPackage Icon Tool] The selected icon's path cannot be found, exporting without icon!");
 
                 SelectedIcon = null;
 
@@ -209,7 +240,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             }
             else if (ImageDetection.GetImageFormat(iconPath) != ImageDetection.ImageFormat.PNG)
             {
-                Debug.LogWarning("[UnityPackage Icon] The selected icon was replaced with a non-PNG file, exporting without icon!");
+                Debug.LogWarning("[UnityPackage Icon Tool] The selected icon was replaced with a non-PNG file, exporting without icon!");
 
                 SelectedIcon = null;
 
@@ -236,7 +267,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"[UnityPackage Icon] {e.Message}");
+                    Debug.LogError($"[UnityPackage Icon Tool] {e.Message}");
                 }
 
                 __instance.Close();
@@ -348,7 +379,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 Type stylesType = typeof(EditorWindow).Assembly.GetType("UnityEditor.PackageExport+Styles");
                 if (stylesType == null)
                 {
-                    Debug.LogError("[UnityPackage Icon] Failed to find the type UnityEditor.PackageExport.Styles!");
+                    Debug.LogError("[UnityPackage Icon Tool] Failed to find the type UnityEditor.PackageExport.Styles!");
 
                     return;
                 }
@@ -360,7 +391,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 }
                 else
                 {
-                    Debug.LogWarning("[UnityPackage Icon] Failed to find the field UnityEditor.PackageExport.Styles.title!");
+                    Debug.LogWarning("[UnityPackage Icon Tool] Failed to find the field UnityEditor.PackageExport.Styles.title!");
                 }
 
                 FieldInfo topBarBgField = stylesType.GetField("topBarBg", BindingFlags.Public | BindingFlags.Static);
@@ -370,7 +401,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 }
                 else
                 {
-                    Debug.LogWarning("[UnityPackage Icon] Failed to find the field UnityEditor.PackageExport.Styles.topBarBgField!");
+                    Debug.LogWarning("[UnityPackage Icon Tool] Failed to find the field UnityEditor.PackageExport.Styles.topBarBgField!");
                 }
 
                 FieldInfo headerField = stylesType.GetField("header", BindingFlags.Public | BindingFlags.Static);
@@ -380,7 +411,7 @@ namespace BUDDYWORKS.UnityPackageIcon
                 }
                 else
                 {
-                    Debug.LogWarning("[UnityPackage Icon] Failed to find the field UnityEditor.PackageExport.Styles.header!");
+                    Debug.LogWarning("[UnityPackage Icon Tool] Failed to find the field UnityEditor.PackageExport.Styles.header!");
                 }
             }
         }

--- a/Editor/UnityPackageIcon.cs
+++ b/Editor/UnityPackageIcon.cs
@@ -129,7 +129,7 @@ namespace BUDDYWORKS.UnityPackageIcon
             Harmony.Patch(showExportPackageMethod, null, new HarmonyMethod(typeof(UnityPackageIcon).GetMethod(nameof(ShowExportPackage), BindingFlags.NonPublic | BindingFlags.Static)));
         }
 
-        [MenuItem("BUDDYWORKS/Set .UnityPackage Icon...")]
+        [MenuItem("BUDDYWORKS/Set .unitypackage Icon...")]
         public static void ShowWindow()
         {
             UnityPackageIcon window = (UnityPackageIcon)GetWindow(typeof(UnityPackageIcon));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "displayName": "BUDDYWORKS UnityPackage Icon Tool",
   "description": "Patches the export dialogue to allow defining an icon.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "unity": "2019.4",
   "gitDependencies": {},
   "vpmDependencies": {},


### PR DESCRIPTION
**Reworked the dedicated window GUI a bit**
- Added some more information and simple styling, the footer opens a browser window to this repo.
- Fixed some funky window behavior by making it non-exclusive (I think `window.ShowModal();` caused some odd behavior, it can be safely omitted, I think.)
![Unity_Kp11GrDy1O](https://github.com/JustBuddy/unitypackage-icon-tool/assets/8122264/4f2871f7-fe3f-440d-b034-46d2fe784aa8)

- Changed target directory to /Assets/ to survive package updates.



